### PR TITLE
Proposal for breaking large scenarios out into separate files

### DIFF
--- a/scenarios/execution/union_interface_types/data.yaml
+++ b/scenarios/execution/union_interface_types/data.yaml
@@ -1,0 +1,16 @@
+bob:
+  type: Person
+  name: Bob
+  pets:
+    - type: Cat
+      name: Garfield
+      meows: false
+    - type: Dog
+      name: Odie
+      barks: true
+  friends:
+    - type: Person
+      name: Liz
+    - type: Dog
+      name: Odie
+      barks: true

--- a/scenarios/execution/union_interface_types/scenario.yaml
+++ b/scenarios/execution/union_interface_types/scenario.yaml
@@ -1,0 +1,6 @@
+scenario: "Execute: Union and intersection types"
+background:
+  schema: schema.yaml
+  test-data-file: data.yaml
+tests:
+  path: tests/*.yaml

--- a/scenarios/execution/union_interface_types/schema.graphql
+++ b/scenarios/execution/union_interface_types/schema.graphql
@@ -1,0 +1,24 @@
+interface Named {
+  name: String
+}
+
+type Dog implements Named {
+  name: String
+  barks: Boolean
+}
+
+type Cat implements Named {
+  name: String
+  meows: Boolean
+}
+
+union Pet = Dog | Cat
+
+type Person implements Named {
+  pets: [Pet]
+  friends: [Named]
+}
+
+schema {
+  query: Person
+}

--- a/scenarios/execution/union_interface_types/tests/1_introspection.yaml
+++ b/scenarios/execution/union_interface_types/tests/1_introspection.yaml
@@ -1,0 +1,49 @@
+name: introspect on union and intersection types
+given:
+  query: |
+    {
+      Named: __type(name: "Named") {
+        kind
+        name
+        fields { name }
+        interfaces { name }
+        possibleTypes { name }
+        enumValues { name }
+        inputFields { name }
+      }
+      Pet: __type(name: "Pet") {
+        kind
+        name
+        fields { name }
+        interfaces { name }
+        possibleTypes { name }
+        enumValues { name }
+        inputFields { name }
+      }
+    }
+when:
+  execute:
+then:
+  data:
+    Named:
+      kind: "INTERFACE"
+      name: "Named"
+      fields:
+        - name: "name"
+      interfaces: null
+      possibleTypes:
+        - name: "Cat"
+        - name: "Dog"
+        - name: "Person"
+      enumValues: null
+      inputFields: null
+    Pet:
+      kind: "UNION"
+      name: "Pet"
+      fields: null
+      interfaces: null
+      possibleTypes:
+        - name: "Dog"
+        - name: "Cat"
+      enumValues: null
+      inputFields: null

--- a/scenarios/execution/union_interface_types/tests/2_union.yaml
+++ b/scenarios/execution/union_interface_types/tests/2_union.yaml
@@ -1,0 +1,29 @@
+name: executes using union types
+given:
+  query: |
+    {
+      __typename
+      name
+      pets {
+        __typename
+        name
+        barks
+        meows
+      }
+    }
+when:
+  execute:
+    validate-query: false
+    test-value: bob
+then:
+  data:
+    __typename: "Person"
+    name: "Bob"
+    pets:
+      - __typename: "Cat"
+        name: "Garfield"
+        meows: false
+      - __typename: "Dog"
+        name: "Odie"
+        barks: true
+        

--- a/scenarios/execution/union_interface_types/tests/3_union_fragments.yaml
+++ b/scenarios/execution/union_interface_types/tests/3_union_fragments.yaml
@@ -1,0 +1,32 @@
+name: executes union types with inline fragments
+given:
+  query: |
+    {
+      __typename
+      name
+      pets {
+        __typename
+        ... on Dog {
+          name
+          barks
+        }
+        ... on Cat {
+          name
+          meows
+        }
+      }
+    }
+when:
+  execute:
+    test-value: bob
+then:
+  data:
+    __typename: "Person"
+    name: "Bob"
+    pets:
+      - __typename: "Cat"
+        name: "Garfield"
+        meows: false
+      - __typename: "Dog"
+        name: "Odie"
+        barks: true

--- a/scenarios/execution/union_interface_types/tests/4_interface.yaml
+++ b/scenarios/execution/union_interface_types/tests/4_interface.yaml
@@ -1,0 +1,27 @@
+name: executes using interface types
+given:
+  query: |
+    {
+      __typename
+      name
+      friends {
+        __typename
+        name
+        barks
+        meows
+      }
+    }
+when:
+  execute:
+    validate-query: false
+    test-value: bob
+then:
+  data:
+    __typename: "Person"
+    name: "Bob"
+    friends:
+      - __typename: "Person"
+        name: "Liz"
+      - __typename: "Dog"
+        name: "Odie"
+        barks: true

--- a/scenarios/execution/union_interface_types/tests/5_interface_inline_fragments.yaml
+++ b/scenarios/execution/union_interface_types/tests/5_interface_inline_fragments.yaml
@@ -1,0 +1,30 @@
+name: executes interface types with inline fragments
+given:
+  query: |
+    {
+      __typename
+      name
+      friends {
+        __typename
+        name
+        ... on Dog {
+          barks
+        }
+        ... on Cat {
+          meows
+        }
+      }
+    }
+when:
+  execute:
+    test-value: bob
+then:
+  data:
+    __typename: "Person"
+    name: "Bob"
+    friends:
+      - __typename: "Person"
+        name: "Liz"
+      - __typename: "Dog"
+        name: "Odie"
+        barks: true

--- a/scenarios/execution/union_interface_types/tests/6_abstract_fragment_conditions.yaml
+++ b/scenarios/execution/union_interface_types/tests/6_abstract_fragment_conditions.yaml
@@ -1,0 +1,45 @@
+name: allows fragment conditions to be abstract types
+given:
+  query: |
+    {
+      __typename
+      name
+      pets { ...PetFields }
+      friends { ...FriendFields }
+    }
+
+    fragment PetFields on Pet {
+      __typename
+      ... on Dog {
+        name
+        barks
+      }
+      ... on Cat {
+        name
+        meows
+      }
+    }
+
+    fragment FriendFields on Named {
+      __typename
+      name
+      ... on Dog {
+        barks
+      }
+      ... on Cat {
+        meows
+      }
+    }
+when:
+  execute:
+    test-value: bob
+then:
+  data:
+    __typename: "Person"
+    name: "Bob"
+    pets:
+      - {__typename: "Cat", name: "Garfield", meows: false}
+      - {__typename: "Dog", name: "Odie", barks: true}
+    friends:
+      - {__typename: "Person", name: "Liz"}
+      - {__typename: "Dog", name: "Odie", barks: true}


### PR DESCRIPTION
Think this might be easier to read and maintain over time.
Wondering whether the schema and data need to be broken out since the
`scenario.yaml` doesn't have much in it any more.

Not sure about number prefixes since this can be tricky if you need to
insert a test in the middle, but it does aid reading by ordering.

Let's discuss.
