### PR TITLE
Add missing `name` field to Person type

### DIFF
--- a/scenarios/execution/UnionInterface.yaml
+++ b/scenarios/execution/UnionInterface.yaml
@@ -18,6 +18,7 @@ background:
     union Pet = Dog | Cat
     
     type Person implements Named {
+      name: String
       pets: [Pet]
       friends: [Named]
     }


### PR DESCRIPTION
A few tests in this scenario were failing in [`graphql-ruby`](https://github.com/rmosolgo/graphql-ruby) because `Person` was missing a `name: String` field since it implements `Named`.

As per the spec:

> The object type must include a field of the same name for every field defined in an interface.

cc @OlegIlyenko 