### PR TITLE
Add scenario for ExecutableDefinitions validation

### DIFF
--- a/scenarios/error-mapping.yaml
+++ b/scenarios/error-mapping.yaml
@@ -9,3 +9,9 @@ noSubselectionAllowed:
   references:
     spec: http://facebook.github.io/graphql/June2018/#sec-Leaf-Field-Selections
     implementation: https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ScalarLeafs.js
+
+nonExecutableDefinition:
+  message: The ${defName} definition is not executable.
+  references:
+    spec: http://facebook.github.io/graphql/June2018/#sec-Executable-Definitions
+    implementation: https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ExecutableDefinitions.js

--- a/scenarios/validation/ExecutableDefinitions.yaml
+++ b/scenarios/validation/ExecutableDefinitions.yaml
@@ -1,0 +1,103 @@
+scenario: 'Validate: Executable definitions'
+background:
+  schema-file: validation.schema.graphql
+tests:
+  - name: with only operation
+    given:
+      query: |-
+        query Foo {
+          dog {
+            name
+          }
+        }
+    when:
+      validate:
+        - ExecutableDefinitions
+    then:
+      passes: true
+  - name: with operation and fragment
+    given:
+      query: |-
+        query Foo {
+          dog {
+            name
+            ...Frag
+          }
+        }
+
+        fragment Frag on Dog {
+          name
+        }
+    when:
+      validate:
+        - ExecutableDefinitions
+    then:
+      passes: true
+  - name: with type definition
+    given:
+      query: |-
+        query Foo {
+          dog {
+            name
+          }
+        }
+
+        type Cow {
+          name: String
+        }
+
+        extend type Dog {
+          color: String
+        }
+    when:
+      validate:
+        - ExecutableDefinitions
+    then:
+      - error-count: 2
+      - error-code: nonExecutableDefinition
+        args:
+          defName: Cow
+        loc:
+          line: 7
+          column: 1
+      - error-code: nonExecutableDefinition
+        args:
+          defName: Dog
+        loc:
+          line: 11
+          column: 1
+  - name: with schema definition
+    given:
+      query: |-
+        schema {
+          query: Query
+        }
+
+        type Query {
+          test: String
+        }
+
+        extend schema @directive
+    when:
+      validate:
+        - ExecutableDefinitions
+    then:
+      - error-count: 3
+      - error-code: nonExecutableDefinition
+        args:
+          defName: schema
+        loc:
+          line: 1
+          column: 1
+      - error-code: nonExecutableDefinition
+        args:
+          defName: Query
+        loc:
+          line: 5
+          column: 1
+      - error-code: nonExecutableDefinition
+        args:
+          defName: schema
+        loc:
+          line: 9
+          column: 1


### PR DESCRIPTION
Here's another scenario I auto-generated from [GraphQL.js](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ExecutableDefinitions.js) over the weekend.

There's still some things I need to fix in the script before committing it, but so far it seems to work fine.

I wanted to try it out in Sangria to confirm the tests are correct, but my knowledge of Scala is quite limited and I was getting some strange failures when running the tests. I probably didn't modify `src/main/scala/sangria/validation/Violation.scala` correctly:

```
[info] - should with schema definition *** FAILED ***
[info]   scala.MatchError: SchemaExtensionDefinition(Vector(),Vector(Directive(directive,Vector(),Vector(),Some(AstLocation(49996dfc-4858-4b44-bcb8-2c7a28b8c9a0,73,10,15)))),Vector(),Vector(),Some(AstLocation(49996dfc-4858-4b44-bcb8-2c7a28b8c9a0,59,10,1))) (of class sangria.ast.SchemaExtensionDefinition)
```