### PR TITLE
Add scenario for FieldsOnCorrectType validation

### DIFF
--- a/scenarios/error-mapping.yaml
+++ b/scenarios/error-mapping.yaml
@@ -15,3 +15,9 @@ nonExecutableDefinition:
   references:
     spec: http://facebook.github.io/graphql/June2018/#sec-Executable-Definitions
     implementation: https://github.com/graphql/graphql-js/blob/master/src/validation/rules/ExecutableDefinitions.js
+
+undefinedField:
+  message: Cannot query field "${fieldName}" on type "${type}".
+  references:
+    spec: http://facebook.github.io/graphql/June2018/#sec-Field-Selections-on-Objects-Interfaces-and-Unions-Types
+    implementation: https://github.com/graphql/graphql-js/blob/master/src/validation/rules/FieldsOnCorrectType.js

--- a/scenarios/validation/FieldsOnCorrectType.yaml
+++ b/scenarios/validation/FieldsOnCorrectType.yaml
@@ -88,14 +88,14 @@ tests:
       - error-count: 2
       - error-code: undefinedField
         args:
-          field: unknown_pet_field
+          fieldName: unknown_pet_field
           type: Pet
         loc:
           line: 2
           column: 3
       - error-code: undefinedField
         args:
-          field: unknown_cat_field
+          fieldName: unknown_cat_field
           type: Cat
         loc:
           line: 4
@@ -113,7 +113,7 @@ tests:
       - error-count: 1
       - error-code: undefinedField
         args:
-          field: meowVolume
+          fieldName: meowVolume
           type: Dog
         loc:
           line: 2
@@ -133,7 +133,7 @@ tests:
       - error-count: 1
       - error-code: undefinedField
         args:
-          field: unknown_field
+          fieldName: unknown_field
           type: Dog
         loc:
           line: 2
@@ -153,7 +153,7 @@ tests:
       - error-count: 1
       - error-code: undefinedField
         args:
-          field: unknown_field
+          fieldName: unknown_field
           type: Pet
         loc:
           line: 3
@@ -173,7 +173,7 @@ tests:
       - error-count: 1
       - error-code: undefinedField
         args:
-          field: meowVolume
+          fieldName: meowVolume
           type: Dog
         loc:
           line: 3
@@ -191,7 +191,7 @@ tests:
       - error-count: 1
       - error-code: undefinedField
         args:
-          field: mooVolume
+          fieldName: mooVolume
           type: Dog
         loc:
           line: 2
@@ -209,7 +209,7 @@ tests:
       - error-count: 1
       - error-code: undefinedField
         args:
-          field: kawVolume
+          fieldName: kawVolume
           type: Dog
         loc:
           line: 2
@@ -227,7 +227,7 @@ tests:
       - error-count: 1
       - error-code: undefinedField
         args:
-          field: tailLength
+          fieldName: tailLength
           type: Pet
         loc:
           line: 2
@@ -245,7 +245,7 @@ tests:
       - error-count: 1
       - error-code: undefinedField
         args:
-          field: nickname
+          fieldName: nickname
           type: Pet
         loc:
           line: 2
@@ -274,7 +274,7 @@ tests:
       - error-count: 1
       - error-code: undefinedField
         args:
-          field: directField
+          fieldName: directField
           type: CatOrDog
         loc:
           line: 2
@@ -292,7 +292,7 @@ tests:
       - error-count: 1
       - error-code: undefinedField
         args:
-          field: name
+          fieldName: name
           type: CatOrDog
         loc:
           line: 2

--- a/scenarios/validation/FieldsOnCorrectType.yaml
+++ b/scenarios/validation/FieldsOnCorrectType.yaml
@@ -1,0 +1,315 @@
+scenario: 'Validate: Fields on correct type'
+background:
+  schema-file: validation.schema.graphql
+tests:
+  - name: Object field selection
+    given:
+      query: |-
+        fragment objectFieldSelection on Dog {
+          __typename
+          name
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      passes: true
+  - name: Aliased object field selection
+    given:
+      query: |-
+        fragment aliasedObjectFieldSelection on Dog {
+          tn : __typename
+          otherName : name
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      passes: true
+  - name: Interface field selection
+    given:
+      query: |-
+        fragment interfaceFieldSelection on Pet {
+          __typename
+          name
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      passes: true
+  - name: Aliased interface field selection
+    given:
+      query: |-
+        fragment interfaceFieldSelection on Pet {
+          otherName : name
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      passes: true
+  - name: Lying alias selection
+    given:
+      query: |-
+        fragment lyingAliasSelection on Dog {
+          name : nickname
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      passes: true
+  - name: Ignores fields on unknown type
+    given:
+      query: |-
+        fragment unknownSelection on UnknownType {
+          unknownField
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      passes: true
+  - name: reports errors when type is known again
+    given:
+      query: |-
+        fragment typeKnownAgain on Pet {
+          unknown_pet_field {
+            ... on Cat {
+              unknown_cat_field
+            }
+          }
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      - error-count: 2
+      - error-code: undefinedField
+        args:
+          field: unknown_pet_field
+          type: Pet
+        loc:
+          line: 2
+          column: 3
+      - error-code: undefinedField
+        args:
+          field: unknown_cat_field
+          type: Cat
+        loc:
+          line: 4
+          column: 7
+  - name: Field not defined on fragment
+    given:
+      query: |-
+        fragment fieldNotDefined on Dog {
+          meowVolume
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      - error-count: 1
+      - error-code: undefinedField
+        args:
+          field: meowVolume
+          type: Dog
+        loc:
+          line: 2
+          column: 3
+  - name: Ignores deeply unknown field
+    given:
+      query: |-
+        fragment deepFieldNotDefined on Dog {
+          unknown_field {
+            deeper_unknown_field
+          }
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      - error-count: 1
+      - error-code: undefinedField
+        args:
+          field: unknown_field
+          type: Dog
+        loc:
+          line: 2
+          column: 3
+  - name: Sub-field not defined
+    given:
+      query: |-
+        fragment subFieldNotDefined on Human {
+          pets {
+            unknown_field
+          }
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      - error-count: 1
+      - error-code: undefinedField
+        args:
+          field: unknown_field
+          type: Pet
+        loc:
+          line: 3
+          column: 5
+  - name: Field not defined on inline fragment
+    given:
+      query: |-
+        fragment fieldNotDefined on Pet {
+          ... on Dog {
+            meowVolume
+          }
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      - error-count: 1
+      - error-code: undefinedField
+        args:
+          field: meowVolume
+          type: Dog
+        loc:
+          line: 3
+          column: 5
+  - name: Aliased field target not defined
+    given:
+      query: |-
+        fragment aliasedFieldTargetNotDefined on Dog {
+          volume : mooVolume
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      - error-count: 1
+      - error-code: undefinedField
+        args:
+          field: mooVolume
+          type: Dog
+        loc:
+          line: 2
+          column: 3
+  - name: Aliased lying field target not defined
+    given:
+      query: |-
+        fragment aliasedLyingFieldTargetNotDefined on Dog {
+          barkVolume : kawVolume
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      - error-count: 1
+      - error-code: undefinedField
+        args:
+          field: kawVolume
+          type: Dog
+        loc:
+          line: 2
+          column: 3
+  - name: Not defined on interface
+    given:
+      query: |-
+        fragment notDefinedOnInterface on Pet {
+          tailLength
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      - error-count: 1
+      - error-code: undefinedField
+        args:
+          field: tailLength
+          type: Pet
+        loc:
+          line: 2
+          column: 3
+  - name: Defined on implementors but not on interface
+    given:
+      query: |-
+        fragment definedOnImplementorsButNotInterface on Pet {
+          nickname
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      - error-count: 1
+      - error-code: undefinedField
+        args:
+          field: nickname
+          type: Pet
+        loc:
+          line: 2
+          column: 3
+  - name: Meta field selection on union
+    given:
+      query: |-
+        fragment directFieldSelectionOnUnion on CatOrDog {
+          __typename
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      passes: true
+  - name: Direct field selection on union
+    given:
+      query: |-
+        fragment directFieldSelectionOnUnion on CatOrDog {
+          directField
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      - error-count: 1
+      - error-code: undefinedField
+        args:
+          field: directField
+          type: CatOrDog
+        loc:
+          line: 2
+          column: 3
+  - name: Defined on implementors queried on union
+    given:
+      query: |-
+        fragment definedOnImplementorsQueriedOnUnion on CatOrDog {
+          name
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      - error-count: 1
+      - error-code: undefinedField
+        args:
+          field: name
+          type: CatOrDog
+        loc:
+          line: 2
+          column: 3
+  - name: valid field in inline fragment
+    given:
+      query: |-
+        fragment objectFieldSelection on Pet {
+          ... on Dog {
+            name
+          }
+          ... {
+            name
+          }
+        }
+    when:
+      validate:
+        - FieldsOnCorrectType
+    then:
+      passes: true


### PR DESCRIPTION
Here's another scenario I've generated from [GraphQL.js's test suite](https://github.com/graphql/graphql-js/blob/master/src/validation/__tests__/FieldsOnCorrectType-test.js).

The scenario appears to pass on Sangria:

```
$ sbt "testOnly *ValidationSpec"
[...]
[info] Validate: Fields on correct type
[info] - should Object field selection
[info] - should Aliased object field selection
[info] - should Interface field selection
[info] - should Aliased interface field selection
[info] - should Lying alias selection
[info] - should Ignores fields on unknown type
[info] - should reports errors when type is known again
[info] - should Field not defined on fragment
[info] - should Ignores deeply unknown field
[info] - should Sub-field not defined
[info] - should Field not defined on inline fragment
[info] - should Aliased field target not defined
[info] - should Aliased lying field target not defined
[info] - should Not defined on interface
[info] - should Defined on implementors but not on interface
[info] - should Meta field selection on union
[info] - should Direct field selection on union
[info] - should Defined on implementors queried on union
[info] - should valid field in inline fragment
[...]
[info] All tests passed.
```