### PR TITLE
Add scenario for FragmentsOnCompositeTypes validation

### DIFF
--- a/scenarios/error-mapping.yaml
+++ b/scenarios/error-mapping.yaml
@@ -21,3 +21,14 @@ undefinedField:
   references:
     spec: http://facebook.github.io/graphql/June2018/#sec-Field-Selections-on-Objects-Interfaces-and-Unions-Types
     implementation: https://github.com/graphql/graphql-js/blob/master/src/validation/rules/FieldsOnCorrectType.js
+
+fragmentOnNonCompositeType:
+  message: Fragment "${fragmentName}" cannot condition on non composite type "${type}".
+  references:
+    spec: http://facebook.github.io/graphql/June2018/#sec-Fragments-On-Composite-Types
+    implementation: https://github.com/graphql/graphql-js/blob/master/src/validation/rules/FragmentsOnCompositeTypes.js
+
+inlineFragmentOnNonCompositeType:
+  message: Fragment cannot condition on non composite type "${type}".
+  references: http://facebook.github.io/graphql/June2018/#sec-Fragments-On-Composite-Types
+    implementation: https://github.com/graphql/graphql-js/blob/master/src/validation/rules/FragmentsOnCompositeTypes.js

--- a/scenarios/validation/FragmentsOnCompositeTypes.yaml
+++ b/scenarios/validation/FragmentsOnCompositeTypes.yaml
@@ -1,0 +1,136 @@
+scenario: 'Validate: Fragments on composite types'
+background:
+  schema-file: validation.schema.graphql
+tests:
+  - name: object is valid fragment type
+    given:
+      query: |-
+        fragment validFragment on Dog {
+          barks
+        }
+    when:
+      validate:
+        - FragmentsOnCompositeTypes
+    then:
+      passes: true
+  - name: interface is valid fragment type
+    given:
+      query: |-
+        fragment validFragment on Pet {
+          name
+        }
+    when:
+      validate:
+        - FragmentsOnCompositeTypes
+    then:
+      passes: true
+  - name: object is valid inline fragment type
+    given:
+      query: |-
+        fragment validFragment on Pet {
+          ... on Dog {
+            barks
+          }
+        }
+    when:
+      validate:
+        - FragmentsOnCompositeTypes
+    then:
+      passes: true
+  - name: inline fragment without type is valid
+    given:
+      query: |-
+        fragment validFragment on Pet {
+          ... {
+            name
+          }
+        }
+    when:
+      validate:
+        - FragmentsOnCompositeTypes
+    then:
+      passes: true
+  - name: union is valid fragment type
+    given:
+      query: |-
+        fragment validFragment on CatOrDog {
+          __typename
+        }
+    when:
+      validate:
+        - FragmentsOnCompositeTypes
+    then:
+      passes: true
+  - name: scalar is invalid fragment type
+    given:
+      query: |-
+        fragment scalarFragment on Boolean {
+          bad
+        }
+    when:
+      validate:
+        - FragmentsOnCompositeTypes
+    then:
+      - error-count: 1
+      - error-code: fragmentOnNonCompositeType
+        args:
+          fragmentName: scalarFragment
+          type: Boolean
+        loc:
+          line: 1
+          column: 28
+  - name: enum is invalid fragment type
+    given:
+      query: |-
+        fragment scalarFragment on FurColor {
+          bad
+        }
+    when:
+      validate:
+        - FragmentsOnCompositeTypes
+    then:
+      - error-count: 1
+      - error-code: fragmentOnNonCompositeType
+        args:
+          fragmentName: scalarFragment
+          type: FurColor
+        loc:
+          line: 1
+          column: 28
+  - name: input object is invalid fragment type
+    given:
+      query: |-
+        fragment inputFragment on ComplexInput {
+          stringField
+        }
+    when:
+      validate:
+        - FragmentsOnCompositeTypes
+    then:
+      - error-count: 1
+      - error-code: fragmentOnNonCompositeType
+        args:
+          fragmentName: inputFragment
+          type: ComplexInput
+        loc:
+          line: 1
+          column: 27
+  - name: scalar is invalid inline fragment type
+    given:
+      query: |-
+        fragment invalidFragment on Pet {
+          ... on String {
+            barks
+          }
+        }
+    when:
+      validate:
+        - FragmentsOnCompositeTypes
+    then:
+      - error-count: 1
+      - error-code: inlineFragmentOnNonCompositeType
+        args:
+          type: String
+        loc:
+          line: 2
+          column: 10


### PR DESCRIPTION
Another scenario extracted from [GraphQL.js' test suite](https://github.com/graphql/graphql-js/blob/master/src/validation/__tests__/FragmentsOnCompositeTypes-test.js).

This one passes on Sangria, but requires a rename: `FragmentsOnCompositeType` => `FragmentsOnCompositeTypes`:

```
$ sbt "testOnly *ValidationSpec"
[...]
[info] Validate: Fragments on composite types
[info] - should object is valid fragment type
[info] - should interface is valid fragment type
[info] - should object is valid inline fragment type
[info] - should inline fragment without type is valid
[info] - should union is valid fragment type
[info] - should scalar is invalid fragment type
[info] - should enum is invalid fragment type
[info] - should input object is invalid fragment type
[info] - should scalar is invalid inline fragment type
[...]
[info] All tests passed.
```